### PR TITLE
Update Readme.md/Meta.md

### DIFF
--- a/0100000000010000/meta.md
+++ b/0100000000010000/meta.md
@@ -14,5 +14,5 @@
 #### Crashes when Mario is waking up in beginning sequence
 * **Workaround:** Use ["Cap Kingdom" save](#cap-kingdom)
 ## :floppy_disk: Saves
-#### [Cap Kingdom](save/cap-kingdom.zip)
+#### [Cap Kingdom](https://github.com/willfaust/title-meta/raw/master/0100000000010000/save/cap-kingdom.zip)
 * **Author:** Will Faust

--- a/01006AA0084FE000/meta.md
+++ b/01006AA0084FE000/meta.md
@@ -15,5 +15,4 @@
 * **Description:** Crashes when game prompts you to name your save
 * **Workaround:** Use ["after first keyboard prompt" save](#after-first-keyboard-prompt)
 ## :floppy_disk: Saves
-#### [after first keyboard prompt](save/after-first-keyboard-prompt.zip)
-* **Author:** Will Faust
+#### [after first keyboard prompt](https://github.com/willfaust/title-meta/raw/master/01006AA0084FE000/save/after-first-keyboard-prompt.zip)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Every title has its own directory, the name of which being its title id
 * Inside a title's directory, there is a `meta.md` file and a `save` directory
 * The `meta.md` file contains the name of the title, commit it was tested on, issues, notes, cheats, and links to saves
-* The `save` folder contains zips of saves that are linked in `meta.md`
+* The `save` folder contains zips of saves that are avaliable for download in `meta.md`
 
 ### Front-end
 * The Skyline app will use our CDN to retrieve useful info from the `meta.md`s corresponding to a user's local titles


### PR DESCRIPTION
Provides direct download links instead of linking to the save file's location in the repository, fixes an issue in github mobile. This is a duplicate pr due to me not updating the readme and "Damascus Gear Operation Tokyo's" Save file.

![PTMD Issue](https://user-images.githubusercontent.com/73195869/111357523-c597b100-865f-11eb-9dbd-3b870fae9d94.png)
![Fix](https://user-images.githubusercontent.com/73195869/111357526-c6304780-865f-11eb-983b-2f7fdc1a94f0.png)

